### PR TITLE
Changed AnalogRead result from AF to HL

### DIFF
--- a/ArduinoInterface/readme.txt
+++ b/ArduinoInterface/readme.txt
@@ -17,7 +17,7 @@ BDOS function 221 (0xDD) - DigitalRead:
  LD D, pin_number
  CALL 5
 
-Result is stored in A.
+Returns result in A (0 = LOW, 1 = HIGH).
 
 =====================================================
 
@@ -36,7 +36,7 @@ BDOS function 223 (0xDF) - AnalogRead:
  LD D, pin_number
  CALL 5
 
-Result is stored in AF.
+Return result in HL (0 - 1023).
 
 =====================================================
 

--- a/cpm.h
+++ b/cpm.h
@@ -862,7 +862,7 @@ void _Bdos(void)
 		C = 223 (DFh) : AnalogRead
 		*/
 	case 223:
-		AF = analogRead(HIGH_REGISTER(DE));
+		HL = analogRead(HIGH_REGISTER(DE));
 		break;
 		/*
 		C = 224 (E0h) : AnalogWrite


### PR DESCRIPTION
According to our discussion at https://github.com/MockbaTheBorg/CPMduino/pull/4 I changed the return register pair from AF to HL. I used HL instead of BC, because looking at http://www.seasip.info/Cpm/bdos.html I see many functions returning 16-bit results in HL, so it seems to be a standard way to do it.